### PR TITLE
Make WebView inspectable

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -275,6 +275,21 @@
     // add to keyWindow to ensure it is 'active'
     [UIApplication.sharedApplication.keyWindow addSubview:self.engineWebView];
 
+    #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400
+        // With the introduction of iOS 16.4 the webview is no longer inspectable by default.
+        // We'll honor that change for release builds, but will still allow inspection on debug builds by default.
+        // We also introduce an override option, so consumers can influence this decision in their own build.
+        if (@available(iOS 16.4, *)) {
+            #ifdef DEBUG
+                BOOL allowWebviewInspectionDefault = YES;
+            #else
+                BOOL allowWebviewInspectionDefault = NO;
+            #endif
+
+            wkWebView.inspectable = [settings cordovaBoolSettingForKey:@"InspectableWebview" defaultValue:allowWebviewInspectionDefault];
+        }
+    #endif
+
     NSString * overrideUserAgent = [settings cordovaSettingForKey:@"OverrideUserAgent"];
     if (overrideUserAgent != nil) {
         wkWebView.customUserAgent = overrideUserAgent;


### PR DESCRIPTION
_"It's an intended change from Apple, starting with iOS 16.4, For any builds using the 16.4 SDK the WebView is no longer inspectable by default and needs the flag. - `InspectableWebview`"_

`cordova-ios` will have an upcoming release containing the fix for that but it turns out that that implementation gets overridden by the Ionic WebView (that hasn't gotten a recent release and doesn't seem like it would get one). Resources:

- https://github.com/apache/cordova-ios/issues/1301#issuecomment-1499093908
- https://github.com/apache/cordova-ios/pull/1300